### PR TITLE
Add .gitattributes for binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+*.jar -diff
+*.png -diff
+*.jpg -diff
+*.jpeg -diff
+*.gif -diff
+*.pdf -diff
+*.zip -diff
+*.rar -diff
+*.7z -diff
+*.mp4 -diff
+*.mov -diff
+*.psd -diff
+*.ai -diff
+*.exe -diff
+*.apk -diff


### PR DESCRIPTION
## Summary
- add a .gitattributes file to disable diffs for common binary formats

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c56154748332b3642b98be898daa