### PR TITLE
Add Android 7 compatibility with launch fallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = "com.virtualsandbox.app"
-        minSdk = 26
+        minSdk = 24
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"

--- a/app/src/main/java/com/virtualsandbox/app/data/virtualization/VirtualEnvironmentController.kt
+++ b/app/src/main/java/com/virtualsandbox/app/data/virtualization/VirtualEnvironmentController.kt
@@ -26,6 +26,10 @@ class VirtualEnvironmentController @Inject constructor(
             context.packageManager.hasSystemFeature(PackageManager.FEATURE_VIRTUALIZATION_FRAMEWORK)
     }
 
+    fun hasLaunchCapability(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+    }
+
     fun canCloneApp(packageName: String): Boolean {
         return try {
             context.packageManager.getPackageInfo(packageName, 0)
@@ -45,25 +49,43 @@ class VirtualEnvironmentController @Inject constructor(
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     fun buildVirtualLaunchIntent(space: SandboxSpace, app: VirtualApp): Intent {
-        val intent = context.packageManager.getLaunchIntentForPackage(app.packageName)
+        return buildBaseLaunchIntent(app).apply {
+            putExtra("virtual_sandbox_space_id", space.id)
+            putExtra("virtual_sandbox_profile", space.profile.name)
+        }
+    }
+
+    private fun buildBaseLaunchIntent(app: VirtualApp): Intent {
+        return context.packageManager.getLaunchIntentForPackage(app.packageName)
+            ?.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
             ?: throw ActivityNotFoundException("앱을 실행할 수 없습니다: ${app.packageName}")
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        intent.putExtra("virtual_sandbox_space_id", space.id)
-        intent.putExtra("virtual_sandbox_profile", space.profile.name)
-        return intent
     }
 
     fun launchVirtualApp(space: SandboxSpace, app: VirtualApp): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            try {
-                val intent = buildVirtualLaunchIntent(space, app)
-                val options = ActivityOptions.makeBasic()
-                ContextCompat.startActivity(context, intent, options.toBundle())
-                true
-            } catch (_: Exception) {
-                false
+        val intent = try {
+            if (isVirtualizationSupported()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                    buildVirtualLaunchIntent(space, app)
+                } else {
+                    buildBaseLaunchIntent(app)
+                }
+            } else {
+                buildBaseLaunchIntent(app)
             }
+        } catch (_: Exception) {
+            return false
+        }
+
+        val options = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && isVirtualizationSupported()) {
+            ActivityOptions.makeBasic().toBundle()
         } else {
+            null
+        }
+
+        return try {
+            ContextCompat.startActivity(context, intent, options)
+            true
+        } catch (_: Exception) {
             false
         }
     }

--- a/app/src/main/java/com/virtualsandbox/app/ui/detail/SpaceDetailScreen.kt
+++ b/app/src/main/java/com/virtualsandbox/app/ui/detail/SpaceDetailScreen.kt
@@ -82,6 +82,7 @@ fun SpaceDetailRoute(
         showAddAppDialog = showAddAppDialog,
         showDeleteDialog = showDeleteDialog,
         onAddApp = viewModel::addVirtualApp,
+        launchEnabled = state.value.launchSupported,
     )
 }
 
@@ -99,6 +100,7 @@ fun SpaceDetailScreen(
     showAddAppDialog: MutableState<Boolean>,
     showDeleteDialog: MutableState<Boolean>,
     onAddApp: (InstalledAppInfo) -> Unit,
+    launchEnabled: Boolean,
 ) {
     val space = state.space
     Scaffold(
@@ -144,6 +146,7 @@ fun SpaceDetailScreen(
                     AppsSection(
                         space = space,
                         virtualizationSupported = state.virtualizationSupported,
+                        launchEnabled = launchEnabled,
                         onLaunchApp = onLaunchApp,
                         onRemoveApp = onRemoveApp,
                         onAddAppClick = onAddAppClick,
@@ -246,6 +249,7 @@ private fun ProfileSection(space: SandboxSpace, onProfileSelected: (SandboxProfi
 private fun AppsSection(
     space: SandboxSpace,
     virtualizationSupported: Boolean,
+    launchEnabled: Boolean,
     onLaunchApp: (Long) -> Unit,
     onRemoveApp: (Long) -> Unit,
     onAddAppClick: () -> Unit,
@@ -271,7 +275,7 @@ private fun AppsSection(
                         packageName = app.packageName,
                         onLaunch = { onLaunchApp(app.id) },
                         onRemove = { onRemoveApp(app.id) },
-                        enabled = virtualizationSupported,
+                        enabled = launchEnabled,
                     )
                 }
             }

--- a/app/src/main/java/com/virtualsandbox/app/ui/detail/SpaceDetailViewModel.kt
+++ b/app/src/main/java/com/virtualsandbox/app/ui/detail/SpaceDetailViewModel.kt
@@ -63,6 +63,7 @@ class SpaceDetailViewModel @Inject constructor(
                         it.copy(
                             space = space,
                             virtualizationSupported = controller.isVirtualizationSupported(),
+                            launchSupported = controller.hasLaunchCapability(),
                             storageUsage = fileManager.calculateDirectorySize(space.storageRoot),
                         )
                     }
@@ -165,7 +166,7 @@ class SpaceDetailViewModel @Inject constructor(
                 updateSandboxSpaceUseCase(space.copy(lastLaunchedAt = System.currentTimeMillis()))
             }
         } else {
-            _state.update { it.copy(errorMessage = context.getString(com.virtualsandbox.app.R.string.space_detail_virtualization_not_supported)) }
+            _state.update { it.copy(errorMessage = context.getString(com.virtualsandbox.app.R.string.space_detail_launch_failed)) }
         }
     }
 
@@ -178,6 +179,7 @@ data class SpaceDetailUiState(
     val space: SandboxSpace? = null,
     val availableApps: List<InstalledAppInfo> = emptyList(),
     val virtualizationSupported: Boolean = false,
+    val launchSupported: Boolean = true,
     val storageUsage: Long = 0,
     val errorMessage: String? = null,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="spaces_empty_title">샌드박스를 만들어보세요</string>
     <string name="spaces_empty_body">가상 환경을 생성하여 앱과 데이터를 격리할 수 있습니다.</string>
     <string name="spaces_create_button">새 샌드박스</string>
-    <string name="spaces_virtualization_not_supported">이 기기는 안드로이드 15 이상의 가상화 프레임워크를 지원하지 않습니다.</string>
+    <string name="spaces_virtualization_not_supported">이 기기는 안드로이드 15 이상의 가상화 프레임워크를 지원하지 않아 앱은 기본 환경에서 실행됩니다.</string>
     <string name="spaces_virtualization_disabled">가상화 기능이 비활성화되어 있습니다. 설정에서 켜주세요.</string>
     <string name="space_detail_storage">저장소 사용량</string>
     <string name="space_detail_launch">가상 앱 실행</string>
@@ -33,7 +33,8 @@
     <string name="settings_virtualization_not_supported">이 기기에서는 가상화를 사용할 수 없습니다.</string>
     <string name="space_detail_storage_placeholder">%1$.2f MB</string>
     <string name="space_detail_no_apps">설치된 가상 앱이 없습니다.</string>
-    <string name="space_detail_virtualization_not_supported">가상화를 지원하지 않아 실제 앱 실행은 불가합니다.</string>
+    <string name="space_detail_virtualization_not_supported">이 기기에서는 가상화를 지원하지 않아 앱이 기본 환경에서 실행됩니다.</string>
+    <string name="space_detail_launch_failed">앱을 실행할 수 없습니다. 설치 상태를 확인해주세요.</string>
     <string name="space_detail_select_profile">선택</string>
     <string name="space_detail_add_to_space">추가</string>
 </resources>


### PR DESCRIPTION
## Summary
- lower the application minSdk to API 24 so Android 7 devices can install the app
- add a standard intent fallback path so apps can still be launched when virtualization is unavailable
- update UI state and messaging to keep launch actions enabled while explaining the virtualization fallback

## Testing
- ./gradlew :app:assembleDebug *(fails: gradle wrapper JAR missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f02286388332a63be6bcdb0db8b0